### PR TITLE
Feature/save pump cnt week

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules/
 venv/
 *.pkl
+*.mp4

--- a/farm-server/services/service_sensor/mqtt_connect.js
+++ b/farm-server/services/service_sensor/mqtt_connect.js
@@ -57,7 +57,7 @@ function updateSectorInfo(database, sensorData)
                     });
             });
             
-            setWeekData(sectorRef); //testing
+            saveWeekData(sectorRef); //testing
         }
     } else {
         console.log("Skipped saving, waiting for 30 seconds interval.");
@@ -211,7 +211,7 @@ function groupByWeek(data) {
 }
 
 // week단위로 센서데이터를 평균내어 저장하는 함수
-function setWeekData(sectorRef)
+function saveWeekData(sectorRef)
 {
     // 섹터별 db의 값을 가져온다
     //const sectorRef = ref(database, `sector/${sector_id}/`);

--- a/farm-server/services/service_sensor/mqtt_connect.js
+++ b/farm-server/services/service_sensor/mqtt_connect.js
@@ -35,6 +35,8 @@ function updateSectorInfo(database, sensorData)
             console.log(sector_id, timeStamp, `sector/${sector_id}/sensorData/`);
             const sectorValue = ref(database, `sector/${sector_id}/sensorData`);
 
+            const sectorRef = ref(database, `sector/${sector_id}/`); //testing
+
             onValue(sectorValue, (snapshot) => {
                 const existingData = snapshot.val() || {}; // 데이터가 없을 때도 existingData 변수가 객체 형식으로 초기화
 
@@ -54,6 +56,8 @@ function updateSectorInfo(database, sensorData)
                         console.error("Error updating data: ", error);
                     });
             });
+            
+            setWeekData(sectorRef); //testing
         }
     } else {
         console.log("Skipped saving, waiting for 30 seconds interval.");
@@ -67,7 +71,7 @@ function receivedMessage(message, database) {
     let sensorData;
 
     try {
-        sensorData = JSON.parse(message.toString());
+        sensorData = JSON.parse(message.toString()); //여기서 에러
         console.log("Parsed sensor data: ", sensorData);
         updateSectorInfo(database, sensorData);
     } catch (error) {
@@ -106,8 +110,10 @@ function setupMQTT(database) {
     const mqtt_topic = "sensor/all"; // 나중에 변경
     client.on('connect', () => {connectionSuccess(client, mqtt_topic)});
     client.on('error', connectionError);
-    client.on('message', (topic, msg) => {receivedMessage(msg, database)});
+    client.on('message', (topic, msg) => {receivedMessage(msg, database, ref)});
 }
+
+setupMQTT(database, );
 
 function getSensorData(database, ref, onValue)
 {
@@ -117,7 +123,6 @@ function getSensorData(database, ref, onValue)
             const data = snapshot.val();
             resolve(data);
         });
-
         // database.ref('sensorValue')
         //     .orderByChild('timestamp') // 타임스탬프 필드를 기준으로 정렬
         //     .startAt(startTime) // 주어진 startTime 이후의 데이터만 필터링
@@ -152,5 +157,94 @@ function getSensorData(database, ref, onValue)
         //     });
     });
 }
+
+// weekly_avg 데이터를 sector/sectorId에 저장하는 함수
+function saveWeeklyAvgToFirebase(sector_id, weeklyData) {
+    // 데이터베이스 경로 설정 (sector/{sector_id}/weekly_avg)
+    const dataRef = ref(database, `sector/${sector_id}/weekly_avg`);
+  
+    // weekly_avg 데이터 저장
+    set(dataRef, weeklyData)
+      .then(() => {
+        console.log('Firebase weekly_avg 저장 성공');
+      })
+      .catch((error) => {
+        console.log('Firebase weekly_avg 저장 실패: ', error);
+      });
+}
+
+// 데이터를 주단위로 묶어주는 함수
+function groupByWeek(data) {
+    const groupedData = [];
+    let currentWeekStart = new Date(data[0].date);
+    let currentWeekData = [];
+
+    data.forEach((entry) => {
+        const diff = (entry.date - currentWeekStart) / (1000 * 60 * 60 * 24); // 날짜 차이 계산 (일 단위)
+
+        if (diff >= 7) {
+            // 현재 주간 데이터 평균 계산
+            groupedData.push({
+                weekStart: currentWeekStart,
+                avgTemperature: currentWeekData.reduce((sum, d) => sum + d.temperature, 0) / currentWeekData.length,
+                avgSoilHumidity: currentWeekData.reduce((sum, d) => sum + d.soil_humidity, 0) / currentWeekData.length
+            });
+
+            // 새로운 주간 데이터 시작
+            currentWeekStart = new Date(entry.date);
+            currentWeekData = [];
+        }
+
+        currentWeekData.push(entry);
+    });
+
+    // 마지막 주간 데이터 처리
+    if (currentWeekData.length > 0) {
+        groupedData.push({
+            weekStart: currentWeekStart,
+            avgTemperature: currentWeekData.reduce((sum, d) => sum + d.temperature, 0) / currentWeekData.length,
+            avgSoilHumidity: currentWeekData.reduce((sum, d) => sum + d.soil_humidity, 0) / currentWeekData.length
+        });
+    }
+
+    return groupedData;  // forEach 루프가 끝난 후 데이터를 반환
+}
+
+// week단위로 센서데이터를 평균내어 저장하는 함수
+function setWeekData(sectorRef)
+{
+    // 섹터별 db의 값을 가져온다
+    //const sectorRef = ref(database, `sector/${sector_id}/`);
+
+    // Firebase에서 상태 값 읽어오기
+    get(sectorRef)
+    .then((snapshot) => {
+        let currentData = snapshot.val();
+        
+        console.log(currentData);
+        const sensorData = currentData.sensorData;
+
+        // 날짜를 기준으로 데이터를 배열로 변환
+        const entries = Object.entries(sensorData).map(([dateString, values]) => ({
+            date: new Date(dateString),
+            ...values
+          }));
+
+        // entry들을 주간별로 그룹핑한다
+        const weeklyData = groupByWeek(entries);
+        //console.log(weeklyData);
+
+        // 주간평균을 DB에 저장한다
+        saveWeeklyAvgToFirebase(sector_id, weeklyData);
+    })
+    .then(() => {
+        console.log("Firebase 읽어오기 성공");
+    })
+    .catch((error) => {
+        console.log("Firebase 저장 실패: ", error);
+    });
+}
+
+
 
 module.exports = { setupMQTT, getSensorData };

--- a/farm-server/services/service_socket-server/DBsave_test.js
+++ b/farm-server/services/service_socket-server/DBsave_test.js
@@ -21,19 +21,75 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const database = getDatabase(app);
 
-// Firebase에 명령 저장하는 함수
-function storeLedStatus(sector_id, state) {
-    const commandRef = ref(database, `sector/${sector_id}/LED_Status/`);
-    set(commandRef, {
-        status: state,
+// 데이터를 주단위로 그루핑하는 함수
+function groupByWeek(data) {
+    const groupedData = [];
+    let currentWeekStart = new Date(data[0].date);
+    let currentWeekData = [];
+
+    data.forEach((entry) => {
+        const diff = (entry.date - currentWeekStart) / (1000 * 60 * 60 * 24); // 날짜 차이 계산 (일 단위)
+
+        if (diff >= 7) {
+            // 현재 주간 데이터 평균 계산
+            groupedData.push({
+                weekStart: currentWeekStart,
+                avgTemperature: currentWeekData.reduce((sum, d) => sum + d.temperature, 0) / currentWeekData.length,
+                avgSoilHumidity: currentWeekData.reduce((sum, d) => sum + d.soil_humidity, 0) / currentWeekData.length
+            });
+
+            // 새로운 주간 데이터 시작
+            currentWeekStart = new Date(entry.date);
+            currentWeekData = [];
+        }
+
+        currentWeekData.push(entry);
+    });
+
+    // 마지막 주간 데이터 처리
+    if (currentWeekData.length > 0) {
+        groupedData.push({
+            weekStart: currentWeekStart,
+            avgTemperature: currentWeekData.reduce((sum, d) => sum + d.temperature, 0) / currentWeekData.length,
+            avgSoilHumidity: currentWeekData.reduce((sum, d) => sum + d.soil_humidity, 0) / currentWeekData.length
+        });
+    }
+
+    return groupedData;  // forEach 루프가 끝난 후 데이터를 반환
+}
+
+// week단위로 데이터를 저장하는 함수
+function setWeekData(sector_id)
+{
+    // 섹터별 db의 값을 가져온다
+    const sectorRef = ref(database, `sector/${sector_id}/`);
+
+    // Firebase에서 상태 값 읽어오기
+    get(sectorRef)
+    .then((snapshot) => {
+        let currentData = snapshot.val();
+        
+        console.log(currentData);
+        const sensorData = currentData.sensorData;
+
+        // 날짜를 기준으로 데이터를 배열로 변환
+        const entries = Object.entries(sensorData).map(([dateString, values]) => ({
+            date: new Date(dateString),
+            ...values
+          }));
+
+        const groupedData = groupByWeek(entries);
+        console.log(groupedData);
     })
     .then(() => {
-        console.log("Firebase 저장 성공");
+        console.log("Firebase 읽어오기 성공");
     })
     .catch((error) => {
         console.log("Firebase 저장 실패: ", error);
     });
 }
+
+setWeekData(1);
 
 // storePumpStatus and add Pump_count
 function storePumpStatus(sector_id, state) {
@@ -61,5 +117,3 @@ function storePumpStatus(sector_id, state) {
         console.log("Firebase 저장 실패: ", error);
     });
 }
-
-storePumpStatus(1, "ON");

--- a/farm-server/services/service_socket-server/DBsave_test.js
+++ b/farm-server/services/service_socket-server/DBsave_test.js
@@ -1,0 +1,65 @@
+// const WebSocket = require("ws");
+// const mqtt = require('mqtt');
+// const { database } = require('./firebase.js');
+const { ref, set, get } = require('firebase/database');
+
+const initializeApp = require('firebase/app').initializeApp;
+const getDatabase = require('firebase/database').getDatabase;
+require('dotenv').config({ path: './.env' });
+
+// firebase init
+const firebaseConfig = {
+    apiKey: process.env.APIKEY,
+    authDomain: process.env.AUTH_DOMAIN,
+    databaseURL: process.env.DATABASE_URL,
+    projectId: process.env.PROJECT_ID,
+    storageBucket: process.env.STORAGE_BUCKET,
+    messagingSenderId: process.env.MESSAGING_SENDER_ID,
+    appId: process.env.APP_ID
+};
+
+const app = initializeApp(firebaseConfig);
+const database = getDatabase(app);
+
+// Firebase에 명령 저장하는 함수
+function storeLedStatus(sector_id, state) {
+    const commandRef = ref(database, `sector/${sector_id}/LED_Status/`);
+    set(commandRef, {
+        status: state,
+    })
+    .then(() => {
+        console.log("Firebase 저장 성공");
+    })
+    .catch((error) => {
+        console.log("Firebase 저장 실패: ", error);
+    });
+}
+
+// storePumpStatus and add Pump_count
+function storePumpStatus(sector_id, state) {
+    const commandRef = ref(database, `sector/${sector_id}/Pump_Status/`);
+
+    // Firebase에서 상태 값 읽어오기
+    get(commandRef)
+    .then((snapshot) => {
+        let currentData = snapshot.val();
+
+        let setData = {
+            status: state,
+            count: currentData && currentData.count ? currentData.count : 0
+        };
+        if (state === "ON"){
+            setData.count += 1;
+        }
+        // 상태데이터 설정
+        return set(commandRef, setData);
+    })
+    .then(() => {
+        console.log("Firebase 저장 성공");
+    })
+    .catch((error) => {
+        console.log("Firebase 저장 실패: ", error);
+    });
+}
+
+storePumpStatus(1, "ON");

--- a/farm-server/services/service_socket-server/DBsave_test.js
+++ b/farm-server/services/service_socket-server/DBsave_test.js
@@ -143,11 +143,11 @@ function saveWeeklyPumpData(sector_id, count) {
 
 // storePumpStatus and add Pump_count
 function storePumpStatus(sector_id, state) {
-    const commandRef = ref(database, `sector/${sector_id}/Pump_Status/`);
+    const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`);
     const currentTime = new Date();  // 현재 시간을 Date 객체로 가져옴
 
     // Firebase에서 상태 값 읽어오기
-    get(commandRef)
+    get(pumpRef)
     .then((snapshot) => {
         let currentData = snapshot.val();
         
@@ -174,7 +174,7 @@ function storePumpStatus(sector_id, state) {
             setData.count += 1;
         }
         // 상태데이터 설정
-        return set(commandRef, setData);
+        return set(pumpRef, setData);
     })
     .then(() => {
         console.log("Firebase 저장 성공");

--- a/farm-server/services/service_socket-server/DBsave_test.js
+++ b/farm-server/services/service_socket-server/DBsave_test.js
@@ -21,7 +21,22 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const database = getDatabase(app);
 
-// 데이터를 주단위로 그루핑하는 함수
+// weekly_avg 데이터를 sector/0에 저장하는 함수
+function saveWeeklyAvgToFirebase(sector_id, weeklyData) {
+    // 데이터베이스 경로 설정 (sector/{sector_id}/weekly_avg)
+    const dataRef = ref(database, `sector/${sector_id}/weekly_avg`);
+  
+    // weekly_avg 데이터 저장
+    set(dataRef, weeklyData)
+      .then(() => {
+        console.log('Firebase weekly_avg 저장 성공');
+      })
+      .catch((error) => {
+        console.log('Firebase weekly_avg 저장 실패: ', error);
+      });
+  }
+
+// 데이터를 주단위로 묶어주는 함수
 function groupByWeek(data) {
     const groupedData = [];
     let currentWeekStart = new Date(data[0].date);
@@ -58,7 +73,7 @@ function groupByWeek(data) {
     return groupedData;  // forEach 루프가 끝난 후 데이터를 반환
 }
 
-// week단위로 데이터를 저장하는 함수
+// week단위로 센서데이터를 평균내어 저장하는 함수
 function setWeekData(sector_id)
 {
     // 섹터별 db의 값을 가져온다
@@ -78,8 +93,12 @@ function setWeekData(sector_id)
             ...values
           }));
 
-        const groupedData = groupByWeek(entries);
-        console.log(groupedData);
+        // entry들을 주간별로 그룹핑한다
+        const weeklyData = groupByWeek(entries);
+        //console.log(weeklyData);
+
+        // 주간평균을 DB에 저장한다
+        saveWeeklyAvgToFirebase(sector_id, weeklyData);
     })
     .then(() => {
         console.log("Firebase 읽어오기 성공");
@@ -89,7 +108,7 @@ function setWeekData(sector_id)
     });
 }
 
-setWeekData(1);
+setWeekData(0);
 
 // storePumpStatus and add Pump_count
 function storePumpStatus(sector_id, state) {

--- a/farm-server/services/service_socket-server/DBsave_test.js
+++ b/farm-server/services/service_socket-server/DBsave_test.js
@@ -1,25 +1,5 @@
-// const WebSocket = require("ws");
-// const mqtt = require('mqtt');
-// const { database } = require('./firebase.js');
+const database = require('./firebase.js');
 const { ref, set, get } = require('firebase/database');
-
-const initializeApp = require('firebase/app').initializeApp;
-const getDatabase = require('firebase/database').getDatabase;
-require('dotenv').config({ path: './.env' });
-
-// firebase init
-const firebaseConfig = {
-    apiKey: process.env.APIKEY,
-    authDomain: process.env.AUTH_DOMAIN,
-    databaseURL: process.env.DATABASE_URL,
-    projectId: process.env.PROJECT_ID,
-    storageBucket: process.env.STORAGE_BUCKET,
-    messagingSenderId: process.env.MESSAGING_SENDER_ID,
-    appId: process.env.APP_ID
-};
-
-const app = initializeApp(firebaseConfig);
-const database = getDatabase(app);
 
 // weekly_avg 데이터를 sector/sectorId에 저장하는 함수
 function saveWeeklyAvgToFirebase(sector_id, weeklyData) {

--- a/farm-server/services/service_socket-server/service_main.js
+++ b/farm-server/services/service_socket-server/service_main.js
@@ -3,7 +3,9 @@ const pkgInfo = require('./package.json');
 const Service = require('webos-service');
 const service = new Service(pkgInfo.name);
 const mqtt = require('mqtt');
-const { database } = require('./firebase.js');
+// const { database } = require('./firebase.js');
+const database = require('./firebase.js');
+console.log("database: ",database);
 const { ref, set, get } = require('firebase/database');
 const logHeader = "[" + pkgInfo.name + "]";
 
@@ -61,7 +63,7 @@ function saveWeeklyPumpData(sector_id, count) {
 
 // storePumpStatus and add Pump_count
 function storePumpStatus(sector_id, state) {
-    const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`);
+    const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`); //여기서 터짐
     const currentTime = new Date();
 
     // get data from Firebase
@@ -134,7 +136,7 @@ function publishToMQTT(topic, command) {
 // serverStart Status
 let serverStarted = false;
 
-//
+// register service
 function socketServer(message) {
     console.log("In sensorControlServer callback");
     try {

--- a/farm-server/services/service_socket-server/service_main.js
+++ b/farm-server/services/service_socket-server/service_main.js
@@ -3,10 +3,8 @@ const pkgInfo = require('./package.json');
 const Service = require('webos-service');
 const service = new Service(pkgInfo.name);
 const mqtt = require('mqtt');
-// const { database } = require('./firebase.js');
-const database = require('./firebase.js');
-console.log("database: ",database);
-const { ref, set, get } = require('firebase/database');
+const { database } = require('./firebase.js');
+const { ref, get, set, transaction } = require('firebase/database');
 const logHeader = "[" + pkgInfo.name + "]";
 
 // Firebase에 명령 저장하는 함수
@@ -23,24 +21,43 @@ function storeLedStatus(sector_id, state) {
     });
 }
 
+// ISO 8601형식의 문자열을 열월일시분초 형식으로 변환
+function formatDate(date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0'); // 월은 0부터 시작하므로 +1
+    const day = String(date.getDate()).padStart(2, '0');
+    
+    const hours = String(date.getHours()).padStart(2, '0');
+    const minutes = String(date.getMinutes()).padStart(2, '0');
+    const seconds = String(date.getSeconds()).padStart(2, '0');
+    
+    return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}
+
 // save weekly pump count to firebase
 function saveWeeklyPumpData(sector_id, count) {
-    let id = 0;  // id is week number
+    let id = 0;  // 주 번호
+    const maxId = 52; // 최대 52주까지만 시도
     const checkAndStore = () => {
+        if (id > maxId) {
+            console.error(`최대 ID ${maxId}까지 데이터를 저장할 수 없습니다.`);
+            return;
+        }
+
         const dataRef = ref(database, `sector/${sector_id}/weekly_avg/${id}`);
-        
-        // read route from Firebase
+
+        // Firebase에서 데이터를 읽고 저장하는 부분
         get(dataRef).then((snapshot) => {
             let currentData = snapshot.val();
             
-            // if threr is no pumpCnt then push data
+            // 데이터가 없거나 pumpCnt가 없으면 새로운 데이터 저장
             if (!currentData || !currentData.pumpCnt) {
                 let setData = {
-                    ...currentData,  // set previous data
-                    pumpCnt: count
+                    ...currentData,  // 기존 데이터 유지
+                    pumpCnt: count   // 새로운 pumpCnt 저장
                 };
 
-                // save data to Firebase
+                // 데이터를 Firebase에 저장
                 return set(dataRef, setData)
                     .then(() => {
                         console.log(`ID ${id}에 pumpCnt 저장 성공`);
@@ -49,7 +66,7 @@ function saveWeeklyPumpData(sector_id, count) {
                         console.error(`ID ${id}에 데이터 저장 실패: `, error);
                     });
             } else {
-                // if there is pumpCnt on this ID then id++
+                // 이미 데이터가 있으면 id 증가 후 다시 시도
                 id++;
                 checkAndStore();
             }
@@ -57,57 +74,16 @@ function saveWeeklyPumpData(sector_id, count) {
             console.error(`Firebase 읽기 실패: `, error);
         });
     };
-    // first call
+
+    // 첫 번째 호출
     checkAndStore();
 }
 
-function storePumpStatus(sector_id, state) {
-    const commandRef = ref(database, `sector/${sector_id}/Pump_Status/`);
-    set(commandRef, {
-        status: state,
-    })
-    .then(() => {
-        console.log("Firebase 저장 성공");
-    })
-    .catch((error) => {
-        console.log("Firebase 저장 실패: ", error);
-    });
-}
 
-// storePumpStatus and add Pump_count
 // function storePumpStatus(sector_id, state) {
-//     const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`); //여기서 터짐
-//     const currentTime = new Date();
-
-//     // get data from Firebase
-//     get(pumpRef)
-//     .then((snapshot) => {
-//         let currentData = snapshot.val();
-        
-//         // startTime이 연월일시분초 형식으로 저장되어 있는 경우 처리
-//         let startTime = currentData && currentData.start ? new Date(currentData.start) : currentTime;
-
-//         // 1주일(7일) 차이가 나는지 계산 (Date 객체끼리 비교)
-//         const timeDifference = (currentTime - startTime) / (1000 * 60 * 60 * 24); // 일 단위 계산
-
-//         let setData = {
-//             status: state,
-//             count: currentData && currentData.count ? currentData.count : 0,
-//             start: formatDate(startTime) // 저장할 때는 연월일시분초 형식으로 변환
-//         };
-
-//         // 1주일 이상 차이가 나면 count를 0으로 초기화하고 start를 현재 시간으로 설정
-//         if (timeDifference >= 7) {
-//             saveWeeklyPumpData(sector_id, currentData.count);
-//             setData.count = 0;
-//             setData.start = formatDate(currentTime); // 새로운 시작 시간을 현재 시간으로 설정
-//         }
-
-//         if (state === "ON") {
-//             setData.count += 1;
-//         }
-//         // 상태데이터 설정
-//         return set(pumpRef, setData);
+//     const commandRef = ref(database, `sector/${sector_id}/Pump_Status/`);
+//     set(commandRef, {
+//         status: state,
 //     })
 //     .then(() => {
 //         console.log("Firebase 저장 성공");
@@ -116,6 +92,49 @@ function storePumpStatus(sector_id, state) {
 //         console.log("Firebase 저장 실패: ", error);
 //     });
 // }
+
+// storePumpStatus and add Pump_count
+function storePumpStatus(sector_id, state) {
+    const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`); //여기서 터짐
+    const currentTime = new Date();
+
+    // get data from Firebase
+    get(pumpRef)
+    .then((snapshot) => {
+        let currentData = snapshot.val();
+        
+        // startTime이 연월일시분초 형식으로 저장되어 있는 경우 처리
+        let startTime = currentData && currentData.start ? new Date(currentData.start) : currentTime;
+
+        // 1주일(7일) 차이가 나는지 계산 (Date 객체끼리 비교)
+        const timeDifference = (currentTime - startTime) / (1000 * 60 * 60 * 24); // 일 단위 계산
+
+        let setData = {
+            status: state,
+            count: currentData && currentData.count ? currentData.count : 0,
+            start: formatDate(startTime) // 저장할 때는 연월일시분초 형식으로 변환
+        };
+
+        // 1주일 이상 차이가 나면 count를 0으로 초기화하고 start를 현재 시간으로 설정
+        if (timeDifference >= 7) {
+            saveWeeklyPumpData(sector_id, currentData.count);
+            setData.count = 0;
+            setData.start = formatDate(currentTime); // 새로운 시작 시간을 현재 시간으로 설정
+        }
+
+        if (state === "ON") {
+            setData.count += 1;
+        }
+        // 상태데이터 설정
+        return set(pumpRef, setData);
+    })
+    .then(() => {
+        console.log("Firebase 저장 성공");
+    })
+    .catch((error) => {
+        console.log("Firebase 저장 실패: ", error);
+    });
+}
 
 //publish command to MQTT brocker
 function publishToMQTT(topic, command) {

--- a/farm-server/services/service_socket-server/service_main.js
+++ b/farm-server/services/service_socket-server/service_main.js
@@ -61,40 +61,10 @@ function saveWeeklyPumpData(sector_id, count) {
     checkAndStore();
 }
 
-// storePumpStatus and add Pump_count
 function storePumpStatus(sector_id, state) {
-    const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`); //여기서 터짐
-    const currentTime = new Date();
-
-    // get data from Firebase
-    get(pumpRef)
-    .then((snapshot) => {
-        let currentData = snapshot.val();
-        
-        // startTime이 연월일시분초 형식으로 저장되어 있는 경우 처리
-        let startTime = currentData && currentData.start ? new Date(currentData.start) : currentTime;
-
-        // 1주일(7일) 차이가 나는지 계산 (Date 객체끼리 비교)
-        const timeDifference = (currentTime - startTime) / (1000 * 60 * 60 * 24); // 일 단위 계산
-
-        let setData = {
-            status: state,
-            count: currentData && currentData.count ? currentData.count : 0,
-            start: formatDate(startTime) // 저장할 때는 연월일시분초 형식으로 변환
-        };
-
-        // 1주일 이상 차이가 나면 count를 0으로 초기화하고 start를 현재 시간으로 설정
-        if (timeDifference >= 7) {
-            saveWeeklyPumpData(sector_id, currentData.count);
-            setData.count = 0;
-            setData.start = formatDate(currentTime); // 새로운 시작 시간을 현재 시간으로 설정
-        }
-
-        if (state === "ON") {
-            setData.count += 1;
-        }
-        // 상태데이터 설정
-        return set(pumpRef, setData);
+    const commandRef = ref(database, `sector/${sector_id}/Pump_Status/`);
+    set(commandRef, {
+        status: state,
     })
     .then(() => {
         console.log("Firebase 저장 성공");
@@ -103,6 +73,49 @@ function storePumpStatus(sector_id, state) {
         console.log("Firebase 저장 실패: ", error);
     });
 }
+
+// storePumpStatus and add Pump_count
+// function storePumpStatus(sector_id, state) {
+//     const pumpRef = ref(database, `sector/${sector_id}/Pump_Status/`); //여기서 터짐
+//     const currentTime = new Date();
+
+//     // get data from Firebase
+//     get(pumpRef)
+//     .then((snapshot) => {
+//         let currentData = snapshot.val();
+        
+//         // startTime이 연월일시분초 형식으로 저장되어 있는 경우 처리
+//         let startTime = currentData && currentData.start ? new Date(currentData.start) : currentTime;
+
+//         // 1주일(7일) 차이가 나는지 계산 (Date 객체끼리 비교)
+//         const timeDifference = (currentTime - startTime) / (1000 * 60 * 60 * 24); // 일 단위 계산
+
+//         let setData = {
+//             status: state,
+//             count: currentData && currentData.count ? currentData.count : 0,
+//             start: formatDate(startTime) // 저장할 때는 연월일시분초 형식으로 변환
+//         };
+
+//         // 1주일 이상 차이가 나면 count를 0으로 초기화하고 start를 현재 시간으로 설정
+//         if (timeDifference >= 7) {
+//             saveWeeklyPumpData(sector_id, currentData.count);
+//             setData.count = 0;
+//             setData.start = formatDate(currentTime); // 새로운 시작 시간을 현재 시간으로 설정
+//         }
+
+//         if (state === "ON") {
+//             setData.count += 1;
+//         }
+//         // 상태데이터 설정
+//         return set(pumpRef, setData);
+//     })
+//     .then(() => {
+//         console.log("Firebase 저장 성공");
+//     })
+//     .catch((error) => {
+//         console.log("Firebase 저장 실패: ", error);
+//     });
+// }
 
 //publish command to MQTT brocker
 function publishToMQTT(topic, command) {


### PR DESCRIPTION
## ADD logic saving weekly pump count & sensor data 

### 1. 작업 내용
- service_sensor
  - mqtt_connect.js 파일의 UpdataSectorInfo함수에 saveWeekData 함수를 실행하도록 추가
  - 기존 로직에서 센서데이터를 저장하는 시점마다 주간 평균을 계산하여 추가로 저장하도록 해놓음
 - service_socket
  - 주간 펌프 사용 횟수 저장 기능 추가
  - 기존의 storePumpStatus로직을 수정
 

### 2. 추가적인 참고 사항 (Additional Notes)
- 센서데이터를 30초마다 저장할때 평균을 매번 연산하니 부담이 증가한다는 문제가 있음 개선필요
